### PR TITLE
fix: parse R-1/... as R/...

### DIFF
--- a/spec/recurring/general.spec.ts
+++ b/spec/recurring/general.spec.ts
@@ -12,6 +12,10 @@ describe('Recurring', () => {
         expect(Recurring.parse('R/2020-01-01/P1Y2M3W4DT5H6M7S')).toEqual({ start: '2020-01-01', duration })
         expect(Recurring.parse('R/P1Y2M3W4DT5H6M7S/2020-01-01')).toEqual({ end: '2020-01-01', duration })
         expect(Recurring.parse('R/P1Y2M3W4DT5H6M7S')).toEqual({ duration })
+
+        expect(Recurring.parse('R-1/2020-01-01/P1Y2M3W4DT5H6M7S')).toEqual({ start: '2020-01-01', duration })
+        expect(Recurring.parse('R-1/P1Y2M3W4DT5H6M7S/2020-01-01')).toEqual({ end: '2020-01-01', duration })
+        expect(Recurring.parse('R-1/P1Y2M3W4DT5H6M7S')).toEqual({ duration })
       })
 
       test('it throws an error when the value is invalid', () => {

--- a/src/recurring.ts
+++ b/src/recurring.ts
@@ -6,7 +6,7 @@ import { DayjsPluginRecurringError } from './errors'
 
 const REGEX_DURATION = /P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?/
 const REGEX_DATE = /.+/
-const REGEX_SE = new RegExp(`^R(?<times>[0-9]*)/(?:(?<start>${REGEX_DATE.source})/(?<duration_a>${REGEX_DURATION.source})|(?<duration_b>${REGEX_DURATION.source})(?:/(?<end>${REGEX_DATE.source}))?)$`)
+const REGEX_SE = new RegExp(`^R(?:(?<times>[0-9]*)|-1)/(?:(?<start>${REGEX_DATE.source})/(?<duration_a>${REGEX_DURATION.source})|(?<duration_b>${REGEX_DURATION.source})(?:/(?<end>${REGEX_DATE.source}))?)$`)
 
 interface ParseOpts {
   times?: number


### PR DESCRIPTION
### Issue

`R-1/` should behave like `R/`. (https://github.com/pubdate/dayjs-plugin-recurring/issues/1)

```js
dayjs('R/2022-01-01/P1Y').isValid() // true
dayjs('R-1/2022-01-01/P1Y').isValid() // false
```

### Solution

Omit `-1` in the regex.

### Potential improvements

- Also add support for `{ times: -1 }` when parsing an object. (probably overkill; potential conflict with [#3](https://github.com/pubdate/dayjs-plugin-recurring/pull/3))
- Add an option on `toString` to output `R-1/` instead of `R/`.
- Save the fact that the input string includes `R-1/` to automatically include it in `toString`. (probably overkill; could also be done for dateFormat; inconsistent behaviour)