### PR TITLE
fix: throw an error when start is after end

### DIFF
--- a/spec/recurring/general.spec.ts
+++ b/spec/recurring/general.spec.ts
@@ -47,6 +47,12 @@ describe('Recurring', () => {
         expect(Recurring.parse({ start: '2020-01-01', end: '2026-03-07T01:30:34', duration })).toEqual({ times: 4, start: '2020-01-01', duration })
         expect(Recurring.parse({ start: '2020-01-01', end: '2026-03-07T01:30:35', duration })).toEqual({ times: 5, start: '2020-01-01', duration })
         expect(Recurring.parse({ start: '2020-01-01', end: '2026-03-07T01:30:36', duration })).toEqual({ times: 5, start: '2020-01-01', duration })
+        expect(Recurring.parse({ start: '2020-01-01', end: '2020-01-01', duration })).toEqual({ times: 0, start: '2020-01-01', duration })
+      })
+
+      test('it throws an error when start and end are provided, times is missing but start is after end', () => {
+        expect(Recurring.parse({ times: 999, start: '2020-01-01', end: '2000-01-01', duration })).toEqual({ times: 999, start: '2020-01-01', duration })
+        expect(() => Recurring.parse({ start: '2020-01-01', end: '2000-01-01', duration })).toThrow('[@pubdate/dayjs-plugin-recurring] recurring_start_after_end')
       })
     })
 

--- a/src/recurring.ts
+++ b/src/recurring.ts
@@ -43,6 +43,7 @@ export default class Recurring {
     // GENERATE times AND REMOVE end/#end WHEN BOTH #start AND #end ARE PROVIDED
     if (this.#start != null && this.#end != null) {
       if (this.times == null) {
+        if (Recurring.dayjsFactory!(this.#start).isAfter(this.#end)) throw new DayjsPluginRecurringError('recurring_start_after_end')
         const recurring = Recurring.parse({ start: this.#start, duration: this.duration })!
         this.#relativeAll = recurring.relativeFirst(Infinity, (date: Dayjs): boolean => !date.isAfter(this.#end))
         this.times = this.#relativeAll.length - 1

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -194,6 +194,7 @@ declare module 'dayjs' {
      * @throws duration_zero
      * @throws duration_float
      * @throws recurring_invalid
+     * @throws recurring_start_after_end
      *
      * @returns A new dayjs instance with the provided recurring.
      * If the recurring has no start and no end, the dayjs instance will be used as start (or as end if `contextAsEnd` option is set to true).


### PR DESCRIPTION
### Issue

`times` should never be negative as [`R-1/` should behave like `R/`](https://github.com/pubdate/dayjs-plugin-recurring/pull/2). And `R-2/` is invalid, afaik. (https://github.com/pubdate/dayjs-plugin-recurring/issues/1)

```js
dayjs().recurring({start: '2022-01-01', end: '2020-01-01', duration: 'P1Y'}).recurring().toString({ dateFormat: 'YYYY-MM-DD' }) // R-1/2022-01-01/P1Y
```

### Solution

I can think of three solutions:
1. Throw an error because it does not make sense for start to be greater than end.
2. Switch start and end (`{ start: '2022-01-01', end: '2020-01-01' }` would be parsed like `{ start: '2020-01-01', end: '2022-01-01' }`).
3. Add support for negative durations and reverse the sign of the duration (`{ start: '2022-01-01', end: '2020-01-01', duration: 'P1Y' }` would become `{ start: '2022-01-01', times: 2, duration: '-P1Y' }`).

Options 2 and 3 do not seem explicit enough and may result in mistakes. There is/should be a better way to do both.
Option 1 (throwing an error) seems to be the cleanest.

### Potential improvements

- Also throw an error for `{ times: -x }` when parsing an object. (probably overkill; potential conflict with [#2](https://github.com/pubdate/dayjs-plugin-recurring/pull/2))
- Throw an error when `times` is a float/not an integer. (probably overkill)